### PR TITLE
README: abbreviated addon registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Next, add `storybook-mobile` to your list of addons:
 module.exports = {
   // other config goes here
   addons: [
-+    'storybook-mobile/register'
-     ],
++    'storybook-mobile'
+  ],
 }
 ```
 


### PR DESCRIPTION
I shortened the setup instructions.

This is better for a few reasons:
- shorter/simpler
- allows you to use [a preset](https://storybook.js.org/docs/presets/introduction/#docs-content) in the future without users needing to change their configs. i suspect if the addon grows in complexity you might want to at some point.

WDYT? (PS this addon is incredible, tremendous work!!! 💯)