### PR TITLE
Fix react hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ This addon works best along with the [@storybook/addon-viewport](https://github.
 ## Contributing
 
 If you have any suggestions or find any bugs, please make an issue or a pr!
+
+**NOTE**: While developing this addon locally you'll need to manually install `peerDependencies` like so:
+
+```bash
+npm install --no-save react react-dom
+```

--- a/package.json
+++ b/package.json
@@ -45,12 +45,11 @@
     "eslint-plugin-prettier": "^3.3.1",
     "evergreen-ui": "^4.29.1",
     "microbundle": "^0.13.0",
-    "prettier": "^2.2.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "dependencies": {
     "@storybook/addons": "^5.3.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9175,15 +9175,6 @@ react-dom@^16.8.3:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.1"
-
 react-draggable@^4.0.3:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.3.1.tgz#f9c0cdcf2279ec5b79c65b70cdfd9361d82fa9ee"
@@ -9377,14 +9368,6 @@ react@^16.8.3:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -9816,14 +9799,6 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
-  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Resolves #25

**Problem**:
> Creating a react component library where components that use react hooks that have storybook and storybook-mobile throw a hooks error in a consuming react app that uses said library.

**Solution**:
Have `react` and `react-dom` ONLY in `peerDependencies`.

**How I've Tested this PR**:
1. Cloned this [example repro of this issue](https://gitlab.com/gaiety/react-peer-dependencies-storybook-mobile-repro)
2. Have this addon cloned locally on this branch
3. In storybook-mobile `yarn` to install dependencies
4. Double check that there is absolutely no `react` or `react-dom` in storybook-mobile's `node_modules`, if there are it won't work. `rm -rf react react-dom` if there are
5. Link storybook-mobile locally to library in the repro. (via `yarn link` or changing the package.json dependency to `link:../path/to/storybook-mobile`
6. In library `yarn` to install dependencies
7. Double check there is no `react` or `react-dom` in library like above, and that there is a `node_modules/storybook-mobile`
8. `yarn build` the library
9. In app, `yarn` and `yarn start`

I know this is a headache to reproduce. I have tested this locally on my machine, storybook-mobile works in the library's storybook on my machine (which to check... you'll need to `npm i --no-save react react-dom` in library and then run `yarn storybook` due to the same peerDependency nonsense) and the library can export components with hooks to a react app without error. I'm happy to pair up on discord or otherwise to assist in reproducing and testing, but this change is pretty simple and likely safe to merge.